### PR TITLE
Make asset downloader that does not use boto3

### DIFF
--- a/sat_cty/city_summary.py
+++ b/sat_cty/city_summary.py
@@ -95,7 +95,7 @@ def s3_to_local(item: pystac.Item, dl_folder: str) -> pystac.Item:
                 with open(f_path, 'wb') as f:
                     for chunk in r.iter_content(chunk_size=8192): 
                         f.write(chunk)
-            
+
         v["href"] = f_path
 
     return item
@@ -121,9 +121,7 @@ def download_items_to_local(item_col: pystac.ItemCollection, bands: list, wkdir:
 
         os.makedirs(dl_dir, exist_ok=True)
 
-        # check if the assets are already downloaded, skip if so
-        if os.path.basename(item.assets[bands[-1]].href) not in os.listdir(dl_dir):
-            item = pystac.Item.from_dict((s3_to_local(item=item.to_dict(), dl_folder=dl_dir)))
+        item = pystac.Item.from_dict((s3_to_local(item=item.to_dict(), dl_folder=dl_dir)))
 
         items_local.append(item)
 
@@ -140,6 +138,9 @@ def make_datacube(items: pystac.ItemCollection, bands, resolution) -> Dataset:
     Return:
         dc (Dataset): space-time datacube    
     """
+
+    logging.info("Making datacube for items: %s", items.items)
+
     output_crs = CRS.from_epsg(items[0].properties["proj:epsg"])
 
     dc = stac_load(
@@ -163,6 +164,8 @@ def calc_ndvi(dc: Dataset, red_band_name: str, nir_band_name: str) -> Dataset:
     Returns:
         dc (Dataset): datacube with NDVI variable
     """
+
+    logging.info("Calculating NDVI for %s", dc)
 
     dc["NDVI"] = (dc[nir_band_name] - dc[red_band_name])/(dc[nir_band_name] + dc[red_band_name])
 

--- a/sat_cty/city_summary.py
+++ b/sat_cty/city_summary.py
@@ -85,17 +85,17 @@ def s3_to_local(item: pystac.Item, dl_folder: str) -> pystac.Item:
         
     """
 
-    for k, v in item["assets"].items():
+    for v in item["assets"].values():
         fn = os.path.basename(v["href"])
         f_path = os.path.join(dl_folder, fn)
         if not os.path.exists(f_path):
-            response = requests.get(v["href"])
-
-            with open(f_path, "wb") as f:
-                f.write(response.content)
+            with requests.get(v["href"], stream=True) as r:
+                r.raise_for_status()
+                with open(f_path, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=8192): 
+                        f.write(chunk)
             
         v["href"] = f_path
-
 
     return item
 

--- a/sat_cty/city_summary.py
+++ b/sat_cty/city_summary.py
@@ -78,10 +78,11 @@ def s3_to_local(item: pystac.Item, dl_folder: str) -> pystac.Item:
     """Take in pystac item, download its assets, and update the asset href to point
     to dl location.
     Args:
-        item (pystac.Item)
-        dl_folder (str)
+        item (pystac.Item): the item to download the assets for
+        dl_folder (str): the path to put the files
 
     Returns:
+        item (pystac.Item): the item with downloaded assets and updated asset hrefs
         
     """
 
@@ -89,7 +90,7 @@ def s3_to_local(item: pystac.Item, dl_folder: str) -> pystac.Item:
         fn = os.path.basename(v["href"])
         f_path = os.path.join(dl_folder, fn)
         if not os.path.exists(f_path):
-            with requests.get(v["href"], stream=True) as r:
+            with requests.get(v["href"], timeout=60, stream=True) as r:
                 r.raise_for_status()
                 with open(f_path, 'wb') as f:
                     for chunk in r.iter_content(chunk_size=8192): 
@@ -181,7 +182,7 @@ if __name__ == "__main__":
     
     # currently only the sentinel-2 data are downloadable from this script b/c missing auth for landsat
     # landsat_sr_endpoint = "https://landsatlook.usgs.gov/stac-server" 
-    
+
     earthsearch_stac_endpoint = "https://earth-search.aws.element84.com/v0"
     collections = ["sentinel-s2-l2a-cogs"]
 

--- a/sat_cty/city_summary.py
+++ b/sat_cty/city_summary.py
@@ -177,11 +177,11 @@ if __name__ == "__main__":
         level=logging.INFO,
     )
 
-    wkdir = "/tmp/sat-cty"
+    wkdir = sys.argv[1] if len(sys.argv) > 1 else "/data/sat-cty"
     
     # currently only the sentinel-2 data are downloadable from this script b/c missing auth for landsat
     # landsat_sr_endpoint = "https://landsatlook.usgs.gov/stac-server" 
-
+    
     earthsearch_stac_endpoint = "https://earth-search.aws.element84.com/v0"
     collections = ["sentinel-s2-l2a-cogs"]
 


### PR DESCRIPTION
the `download_item_assets` method from `cirrus.lib` uses `boto3`, but does not seem to allow anonymous downloads, which is problematic.